### PR TITLE
プロトタイプ一覧表示機能2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,5 @@ end
 
 gem 'pry-rails'
 gem 'devise'
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,10 +97,14 @@ GEM
       responders
       warden (~> 1.2.3)
     erubi (1.12.0)
+    ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.1)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
@@ -122,6 +126,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.1)
@@ -207,6 +212,8 @@ GEM
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -258,8 +265,10 @@ DEPENDENCIES
   capybara
   debug
   devise
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  mini_magick
   mysql2 (~> 0.5)
   pg
   pry-rails

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -2,6 +2,7 @@ class PrototypesController < ApplicationController
   before_action :move_to_index, except:[:index,:show]
 
   def index
+    @prototype = Prototype.all
   end
 
   def new
@@ -13,14 +14,14 @@ class PrototypesController < ApplicationController
     if prototype.save
       redirect_to "/"      
     else
-      render :new      
+      render :new
     end
   end
 
   private
 
   def prototype_params
-    params.require(:prototype).permit(:content, :image).merge(user_id: current_user.id)
+    params.require(:prototype).permit(:title,:catch_copy,:concept,:image).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,5 +1,5 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
+  <%= link_to image_tag(prototype.image.variant(resize: '500x500'), class: :card__img ), root_path%>
   <div class="card__body">
     <%= link_to prototype.title, root_path, class: :card__title%>
     <p class="card__summary">
@@ -7,5 +7,4 @@
     </p>
     <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
   </div>
-  <%= image_tag prototype.image.variant(resize: '500x500'), class: 'prototype__image' if prototype.image.attached? %>
 </div>

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,11 +1,11 @@
 <div class="card">
-  <%= link_to image_tag("プロトタイプの画像", class: :card__img ), root_path%>
+  <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
   <div class="card__body">
-    <%= link_to "プロトタイプのタイトル", root_path, class: :card__title%>
+    <%= link_to prototype.title, root_path, class: :card__title%>
     <p class="card__summary">
-      <%= "プロトタイプのキャッチコピー" %>
+      <%= prototype.catch_copy %>
     </p>
-    <%= link_to "by プロトタイプの投稿者名", root_path, class: :card__user %>
+    <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
   </div>
-  <%= image_tag protospace.image.variant(resize: '500x500'), class: 'protospace-image' if protospace.image.attached? %>
+  <%= image_tag prototype.image.variant(resize: '500x500'), class: 'prototype__image' if prototype.image.attached? %>
 </div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -1,14 +1,14 @@
 <main class="main">
   <div class="inner">
-    <%# ログインしているときは以下を表示する %>
     <% if user_signed_in? %>
       <div class="greeting">
         こんにちは、<%= link_to "#{current_user.name}さん", root_path, class: :greeting__link %>
       </div>
     <% end %>
-    <%# // 以上 %>
     <div class="card__wrapper">
-      <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
+      <% @prototype.each do |prototype|%>
+      <%= render partial:"prototype",locals:{prototype: prototype} %>
+      <% end %>
     </div>
   </div>
 </main>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Protospace150D
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
+    config.active_storage.variant_processor = :mini_magick
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
＃what
プロトタイプ一覧表示ページは、ログイン状況に関係なく、誰でも見ることができること。
投稿されているプロトタイプが一覧で表示されること。
プロトタイプ毎に、「画像・プロトタイプ名・キャッチコピー・投稿者の名前」の4つの情報が表示されること
画像が表示されており、画像がリンク切れなどになっていないこと。（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）

＃why
プロトタイプ一覧表示ページ実装のため