### PR TITLE
ユーザー詳細ページ機能2

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
-  def index
+
+  def show
+    @user = User.find(params[:id])
+    @prototypes = @user.prototypes
   end
 end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
+    <%= link_to "by #{prototype.user.name}", user_path(prototype.user_id), class: :card__user %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,33 +2,35 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= "#{@user.name}さんの情報"%>
       </h2>
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @user.occupation %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @user.position %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= "#{@user.name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
-        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <% @prototypes.each do |prototype| %>
+        <%= render partial:"/prototypes/prototype",locals:{prototype: prototype}%>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
    devise_for :users
    root to: 'prototypes#index'
+   resources :users, only: :show
    resources :prototypes
 end


### PR DESCRIPTION
#what
ユーザー詳細表示ページは、ログイン状況に関係なく、誰でも見ることができること。
各ページのユーザー名をクリックすると、該当ユーザーの詳細ページへ遷移すること。
ユーザーの詳細ページには、そのユーザーの詳細情報（名前・プロフィール・所属・役職）が表示されていること。
ユーザーの詳細ページには、そのユーザーが投稿したプロトタイプの情報（プロトタイプ名・投稿者・画像・キャッチコピー・コンセプト）が表示されていること。
プロトタイプ情報の画像が表示されており、画像がリンク切れなどになっていないこと（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）

#why
ユーザー詳細ページ機能実装のため